### PR TITLE
Use docusaurus/core >= 2.0.0-beta.9 to fix ERESOLVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "docusaurus-plugin-less",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "author": "nonoroazoro",
     "description": "Provides support for Less to Docusaurus v2.",
     "main": "index.js",
@@ -19,7 +19,7 @@
         "less"
     ],
     "peerDependencies": {
-        "@docusaurus/core": ">=2.0.0",
+        "@docusaurus/core": ">=2.0.0-beta.9",
         "less-loader": ">=10.0.0",
         "less": ">=4.0.0"
     }


### PR DESCRIPTION
The v2.0.0 of docusaurus/core is not released yet, and this causes the ERESOLVE issue

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: styra-das@0.0.0
npm ERR! Found: @docusaurus/core@2.0.0-beta.ff31de0ff
npm ERR! node_modules/@docusaurus/core
npm ERR!   @docusaurus/core@"^2.0.0-beta.9" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer @docusaurus/core@">=2.0.0" from docusaurus-plugin-less@2.0.1
npm ERR! node_modules/docusaurus-plugin-less
npm ERR!   docusaurus-plugin-less@"^2.0.1" from the root project
```